### PR TITLE
Add support for emails

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -104,6 +104,34 @@ ordered-set = ">=4.0.2,<4.2.0"
 cli = ["click (==8.1.3)", "pyyaml (==6.0)"]
 
 [[package]]
+name = "dnspython"
+version = "2.2.1"
+description = "DNS toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.extras]
+dnssec = ["cryptography (>=2.6,<37.0)"]
+curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
+doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.10.0)"]
+idna = ["idna (>=2.1,<4.0)"]
+trio = ["trio (>=0.14,<0.20)"]
+wmi = ["wmi (>=1.5.1,<2.0.0)"]
+
+[[package]]
+name = "email-validator"
+version = "1.3.0"
+description = "A robust email address syntax and deliverability validation library."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+dnspython = ">=1.15.0"
+idna = ">=2.0.0"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
@@ -289,6 +317,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -465,7 +494,7 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9.0,<4"
-content-hash = "14c801c2cd51b34fd935df25ba63aa4d3195d59bce579c89fa3c524f58cff66c"
+content-hash = "64cb7bfa25758e1b6b411957324132c12b82d4178326ac4280fbb9f6dbcaa333"
 
 [metadata.files]
 anyio = [
@@ -490,6 +519,11 @@ colored = [
 ]
 commonmark = []
 deepdiff = []
+dnspython = [
+    {file = "dnspython-2.2.1-py3-none-any.whl", hash = "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"},
+    {file = "dnspython-2.2.1.tar.gz", hash = "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e"},
+]
+email-validator = []
 exceptiongroup = []
 fastapi = []
 flake8 = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ typer = {version = "^0.7.0", extras = ["all"]}
 deepdiff = "^6.2.2"
 fastapi = "^0.88.0"
 stringcase = "^1.2.0"
+pydantic = {version = "^1.10.2", extras = ["email"]}
 
 [tool.poetry.dev-dependencies]
 isort = "^5.11.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-product-definition-tooling"
-version = "0.0.7"
+version = "0.0.8"
 description = "Data Product Definition Tooling"
 authors = ["Digital Living International Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Add `email` to the extras for `pydantic` (and install it explicitly instead of implicitly due to other things depending on it) in order to be able to add `EmailStr` etc. in definitions.