### PR TITLE
Speed up conversion of definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-product-definition-tooling"
-version = "0.0.12"
+version = "0.0.13"
 description = "Data Product Definition Tooling"
 authors = ["IOXIO Ltd"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Running the pre-commit hooks one by one of the files seemed to cause an overhead of about 6 seconds per file or 132 seconds for converting and updating 29 files. By running the pre-commit hooks on them only once we can shorten down this to only one invocation and thus process the same 29 files in around 7 seconds in total.